### PR TITLE
docs: update readme with deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Autoscaling model server bundle
+# Autoscaling model serving bundle
 
-The autoscaling model server bundle is comprised of:
+The autoscaling model serving bundle is comprised of:
 
 * `istio-operators`
 * `knative-operators`
@@ -12,11 +12,11 @@ And offers the ability to deploy a model server in any Kubernetes cluster for it
 
 ### Using the Terraform solution
 
-This repository contains a Terraform solution for the `autoscaling-model-server`, for more information on usage, please refer to the [solution README.md](https://github.com/canonical/autoscaling-model-server/tree/track/0.1/terraform).
+This repository contains a Terraform solution for the `autoscaling-model-serving`, for more information on usage, please refer to the [solution README.md](https://github.com/canonical/autoscaling-model-serving/tree/track/0.1/terraform).
 
 ### Charm bundle
 
-The `autoscaling-model-server` is a charm bundle that can be installed with:
+The `autoscaling-model-serving` is a charm bundle that can be installed with:
 
 ```
 juju deploy ./bundle/bundle.yaml --trust
@@ -28,6 +28,6 @@ After the bundle is deployed, the following configuration is required:
 
 ```
 # Namespace of the Istio ingress gateway
-# This value is the model name where the autoscaling-model-server bundle was deployed
+# This value is the model name where the autoscaling-model-serving bundle was deployed
 juju config knative-serving istio.gateway.namespace="<namespace of the Istio ingress gateway>"
 ```

--- a/README.md
+++ b/README.md
@@ -10,17 +10,23 @@ And offers the ability to deploy a model server in any Kubernetes cluster for it
 
 ## Install
 
+### Using the Terraform solution
+
+This repository contains a Terraform solution for the `autoscaling-model-server`, for more information on usage, please refer to the [solution README.md](https://github.com/canonical/autoscaling-model-server/tree/track/0.1/terraform).
+
 ### Charm bundle
 
 The `autoscaling-model-server` is a charm bundle that can be installed with:
 
 ```
-juju deploy autoscaling-model-server --trust
+juju deploy ./bundle/bundle.yaml --trust
+```
 
-# Configure knative-serving with Istio information
-# Name of the Istio ingress gateway
-juju config knative-serving istio.gateway.name=$(juju config istio-pilot default-gateway)
+### Required configuration
 
+After the bundle is deployed, the following configuration is required:
+
+```
 # Namespace of the Istio ingress gateway
 # This value is the model name where the autoscaling-model-server bundle was deployed
 juju config knative-serving istio.gateway.namespace="<namespace of the Istio ingress gateway>"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,7 +1,7 @@
-# Autoscaling model server Terraform solution
+# Autoscaling model serving Terraform solution
 
 
-This is a Terraform module facilitating the deployment of the Autoscaling model server solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+This is a Terraform module facilitating the deployment of the Autoscaling model serving solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## API
 


### PR DESCRIPTION
This commit updates the README with instructions on how to deploy the solution using both the bundle.yaml and the TF module. More detailed docs will be provided in charmed-kubeflow.io/docs (with usage and examples).

Part of #7