### PR TITLE
feat: use Istio gateway default value

### DIFF
--- a/bundle/bundle.yaml
+++ b/bundle/bundle.yaml
@@ -23,6 +23,7 @@ applications:
     scale: 1
     options:
       namespace: knative-serving
+      istio.gateway.name: istio-gateway
     trust: true
   kserve-controller:
     charm: kserve-controller


### PR DESCRIPTION
Use the default value from istio-pilot's configuration value of default-gateway to configure knative-serving's istio.gateway.name configuration value.