### PR TITLE
chore: replace server with serving in all files of the repo

### DIFF
--- a/terraform/cos_configuration.tf
+++ b/terraform/cos_configuration.tf
@@ -1,6 +1,6 @@
 # This module is not exposing the storage directives input, thus it
 # cannot be set in this solution's module. See for reference:
-# https://github.com/canonical/autoscaling-model-server/issues/6
+# https://github.com/canonical/autoscaling-model-serving/issues/6
 module "grafana_agent_k8s" {
   count = var.cos_configuration && var.existing_grafana_agent_name == null ? 1 : 0
   # tflint-ignore: terraform_module_pinned_source

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -61,5 +61,5 @@ variable "kserve_controller_revision" {
 variable "model" {
   description = "Model name"
   type        = string
-  default     = "as-model-server"
+  default     = "as-model-serving"
 }

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -54,7 +54,7 @@ async def cli_deploy_bundle(ops_test: OpsTest, bundle_path: str):
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
-    """Deploy the autoscaling-model-server bundle."""
+    """Deploy the autoscaling-model-serving bundle."""
     await cli_deploy_bundle(ops_test, bundle_path=BUNDLE_PATH)
     # Configure knative-serving with Istio information
     await ops_test.model.applications["knative-serving"].set_config(


### PR DESCRIPTION
There were missing instances of 'autoscaling model server' that we needed to update to 'autoscaling model serving'.

Fixes #10